### PR TITLE
Fix the email rendering bug (complement 7c7ced3)

### DIFF
--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -106,15 +106,17 @@ class FormDefinition(models.Model):
         # TODO: refactor, move to utils
         from django.template.loader import get_template
         from django.template import Template
+        require_context_obj = False
         if template:
             t = get_template(template)
         elif not self.message_template:
             t = get_template('txt/formdefinition/data_message.txt')
         else:
             t = Template(self.message_template)
+            require_context_obj = True
         context = self.get_form_data_context(form_data)
         context['data'] = form_data
-        if django.VERSION[:2] < (1, 8):
+        if django.VERSION[:2] < (1, 8) or require_context_obj:
             from django.template import Context
             context = Context(context)
         return t.render(context)


### PR DESCRIPTION
Description: When using a specific template (message_template) for the email with
Django1.8, the rendering crashes.

Cause: From Django1.8, get_template returns a backend-dependent Template
which requires a dictionary as a context for 'render'.

7c7ced3 forces the context to be a dictionary if django > 1.8. However, if
a specific email template is provided, the template created is a
django.template.Template which requires a Context object for 'render'.

Fix: This commit forces the context to be a Context object if a specific
email template has been provided.
