### PR TITLE
Add an option to enable html default email template

### DIFF
--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -109,7 +109,7 @@ class FormDefinition(models.Model):
         if template:
             t = get_template(template)
         elif not self.message_template:
-            t = get_template('txt/formdefinition/data_message.txt')
+            t = get_template(settings.EMAIL_TEMPLATE)
         else:
             t = Template(self.message_template)
         context = self.get_form_data_context(form_data)
@@ -152,9 +152,15 @@ class FormDefinition(models.Model):
 
     @property
     def is_template_html(self):
-        if self.message_template and re.search(u"<[^>]+>", self.message_template) and re.search(u"</[^>]+>", self.message_template):
-            return True
-        return False
+        template = self.message_template
+        if template:  # We have a custom inline template string?
+            # Assume the template string is HTML-ish if it has at least one opening
+            # and closing HTML tag:
+            return (re.search(u"<[^>]+>", template) and re.search(u"</[^>]+>", template))
+
+        # If there is no custom inline template, see if the `EMAIL_TEMPLATE`
+        # setting points to a `.html` file:
+        return settings.EMAIL_TEMPLATE.lower().endswith('.html')
 
     @property
     def submit_flag_name(self):

--- a/form_designer/settings.py
+++ b/form_designer/settings.py
@@ -93,3 +93,5 @@ MAX_UPLOAD_TOTAL_SIZE = getattr(settings, 'MAX_UPLOAD_TOTAL_SIZE', 10485760)  # 
 VALUE_PICKLEFIELD = True
 
 DESIGNED_FORM_CLASS = getattr(settings, 'FORM_DESIGNER_DESIGNED_FORM_CLASS', 'form_designer.forms.DesignedForm')
+
+EMAIL_TEMPLATE = getattr(settings, 'FORM_DESIGNER_EMAIL_TEMPLATE', 'txt/formdefinition/data_message.txt')

--- a/form_designer/templates/html/formdefinition/data_table_message.html
+++ b/form_designer/templates/html/formdefinition/data_table_message.html
@@ -1,0 +1,20 @@
+{% load friendly %}
+<html>
+    <head>
+        <style>
+            td {
+                padding: 15px;
+            }
+        </style>
+    </head>
+    <body>
+        <table>
+            {% for item in data %}{% if item.label %}
+                <tr>
+                    <td>{{ item.label }}{% else %}{{ item.name }}{% endif %}:</td>
+                    <td><strong> {{ item.value|friendly|safe }}</strong></td>
+                </tr>
+            {% endfor %}
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
Add a default html email template that displays the fields and values in a
0 border table, values being highlighted with strong

Add a checkbox to enable the html default template

no ref
