### PR TITLE
Add mail cover text to formdefenition model.

### DIFF
--- a/form_designer/admin.py
+++ b/form_designer/admin.py
@@ -31,7 +31,7 @@ class FormDefinitionAdmin(admin.ModelAdmin):
     fieldsets = [
         (_('Basic'), {'fields': ['name', 'require_hash', 'method', 'action', 'title', 'body']}),
         (_('Settings'), {'fields': ['allow_get_initial', 'log_data', 'success_redirect', 'success_clear', 'display_logged', 'save_uploaded_files'], 'classes': ['collapse']}),
-        (_('Mail form'), {'fields': ['mail_to', 'mail_from', 'mail_subject', 'mail_uploaded_files'], 'classes': ['collapse']}),
+        (_('Mail form'), {'fields': ['mail_to', 'mail_from', 'mail_subject', 'mail_uploaded_files', 'mail_cover_text'], 'classes': ['collapse']}),
         (_('Templates'), {'fields': ['message_template', 'form_template_name'], 'classes': ['collapse']}),
         (_('Messages'), {'fields': ['success_message', 'error_message', 'submit_label'], 'classes': ['collapse']}),
     ]

--- a/form_designer/migrations/0003_mail_cover_text.py
+++ b/form_designer/migrations/0003_mail_cover_text.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import form_designer.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('form_designer', '0002_reply_to'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='formdefinition',
+            name='mail_cover_text',
+            field=models.TextField(help_text='Email cover text which can be included in the default email template and in the message template.', null=True, verbose_name='email cover text', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='formdefinition',
+            name='message_template',
+            field=form_designer.fields.TemplateTextField(help_text='Your form fields are available as template context. Example: "{{ message }}" if you have a field named `message`. To iterate over all fields, use the variable `data` (a list containing a dictionary for each form field, each containing the elements `name`, `label`, `value`). If you have set up email cover text, you can use {{ mail_cover_text }} to access it.', null=True, verbose_name='message template', blank=True),
+        ),
+    ]

--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -41,6 +41,7 @@ class FormDefinition(models.Model):
     title = models.CharField(_('title'), max_length=255, blank=True, null=True)
     body = models.TextField(_('body'), help_text=_('Form description. Display on form after title.'), blank=True, null=True)
     action = models.URLField(_('target URL'), help_text=_('If you leave this empty, the page where the form resides will be requested, and you can use the mail form and logging features. You can also send data to external sites: For instance, enter "http://www.google.ch/search" to create a search form.'), max_length=255, blank=True, null=True)
+    mail_cover_text = models.TextField(_('email cover text'), help_text=_('Email cover text which can be included in the default email template and in the message template.'), blank=True, null=True)
     mail_to = TemplateCharField(_('send form data to e-mail address'), help_text=_('Separate several addresses with a comma. Your form fields are available as template context. Example: "admin@domain.com, {{ from_email }}" if you have a field named `from_email`.'), max_length=255, blank=True, null=True)
     mail_from = TemplateCharField(_('sender address'), max_length=255, help_text=MAIL_TEMPLATE_CONTEXT_HELP_TEXT, blank=True, null=True)
     mail_reply_to = TemplateCharField(_('reply-to address'), max_length=255, help_text=MAIL_TEMPLATE_CONTEXT_HELP_TEXT, blank=True)
@@ -55,7 +56,7 @@ class FormDefinition(models.Model):
     success_redirect = models.BooleanField(_('HTTP redirect after successful submission'), default=True)
     success_clear = models.BooleanField(_('clear form after successful submission'), default=True)
     allow_get_initial = models.BooleanField(_('allow initial values via URL'), help_text=_('If enabled, you can fill in form fields by adding them to the query string.'), default=True)
-    message_template = TemplateTextField(_('message template'), help_text=_('Your form fields are available as template context. Example: "{{ message }}" if you have a field named `message`. To iterate over all fields, use the variable `data` (a list containing a dictionary for each form field, each containing the elements `name`, `label`, `value`).'), blank=True, null=True)
+    message_template = TemplateTextField(_('message template'), help_text=_('Your form fields are available as template context. Example: "{{ message }}" if you have a field named `message`. To iterate over all fields, use the variable `data` (a list containing a dictionary for each form field, each containing the elements `name`, `label`, `value`). If you have set up email cover text, you can use {{ mail_cover_text }} to access it.'), blank=True, null=True)
     form_template_name = models.CharField(_('form template'), max_length=255, blank=True, null=True)
     display_logged = models.BooleanField(_('display logged submissions with form'), default=False)
 
@@ -113,6 +114,7 @@ class FormDefinition(models.Model):
             t = Template(self.message_template)
         context = self.get_form_data_context(form_data)
         context['data'] = form_data
+        context['mail_cover_text'] = self.mail_cover_text or ''
         return t.render(Context(context))
 
     def count_fields(self):


### PR DESCRIPTION
This cover letter can be rendered to default email template or used in
form template as context variable {{mail_cover_letter}}.
