### PR TITLE
 Add related name for cmsplugin ptr

### DIFF
--- a/form_designer/contrib/cms_plugins/form_designer_form/migrations/0001_initial.py
+++ b/form_designer/contrib/cms_plugins/form_designer_form/migrations/0001_initial.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import cms
 from django.db import migrations, models
+from pkg_resources import parse_version as V
+
+# Django CMS 3.3.1 is oldest release where the change affects.
+# Refs https://github.com/divio/django-cms/commit/871a164
+if V(cms.__version__) >= V('3.3.1'):
+    field_kwargs = {'related_name': 'form_designer_form_cmsformdefinition'}
+else:
+    field_kwargs = {}
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('cms', '0001_initial'),
         ('form_designer', '0001_initial'),
@@ -15,12 +23,24 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='CMSFormDefinition',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, auto_created=True, primary_key=True, to='cms.CMSPlugin', parent_link=True)),
-                ('form_definition', models.ForeignKey(verbose_name='form', to='form_designer.FormDefinition')),
+                ('cmsplugin_ptr',
+                 models.OneToOneField(
+                     serialize=False,
+                     auto_created=True,
+                     primary_key=True,
+                     to='cms.CMSPlugin',
+                     parent_link=True,
+                     **field_kwargs)),
+                ('form_definition',
+                 models.ForeignKey(
+                     verbose_name='form',
+                     to='form_designer.FormDefinition')),
             ],
             options={
                 'abstract': False,
             },
-            bases=('cms.cmsplugin',),
+            bases=(
+                'cms.cmsplugin',
+            ),
         ),
     ]


### PR DESCRIPTION
Add the related name for the cmsplugin ptr. The related name is added to the base model in Django CMS see: divio/django-cms@871a164