### PR TITLE
Fix tests for Django 1.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ deps =
     mysqlclient
     pytest
     pytest-cov
-    pytest-django
+    django17: pytest-django>=3.1,<3.2
+    django{18,19,110,111,20}: pytest-django
     xlwt
 commands =
     py.test -ra --cov form_designer --cov-report term --cov-report html form_designer {posargs}


### PR DESCRIPTION
Tox: Use older pytest-django for Django 1.7

It seems that pytest-django 3.2.1 doesn't work with Django 1.7, so use
older version of pytest-django (3.1.x) with Django 1.7.

The build failed with an error with the following traceback with
pytest-django 3.2.1 and Django 1.7:

    File ".../pytest_django/plugin.py", line 153, in _setup_django
      _blocking_manager.block()
    File ".../pytest_django/plugin.py", line 641, in block
      self._save_active_wrapper()
    File ".../pytest_django/plugin.py", line 624, in _save_active_wrapper
      return self._history.append(self._dj_db_wrapper.ensure_connection)
    File ".../pytest_django/plugin.py", line 614, in _dj_db_wrapper
      from django.db.backends.base.base import BaseDatabaseWrapper

    ImportError: No module named base.base
