### PR TITLE
Django 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-install: pip install -U pip tox-travis codecov
-script: tox
+install:
+  - pip install -U pip
+  - pip install 'tox>=3.4.0' tox-travis codecov
+script: tox -vv -r
 after_success: codecov -e TRAVIS_PYTHON_VERSION -e DATABASE

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ This fork is compatible with Django 1.7+ and Python 2.7+.
 General
 =======
 
-A Django admin app with a GUI to create complex forms without any programming skills; 
+A Django admin app with a GUI to create complex forms without any programming skills;
 complete with logging, validation, and redirects.
 
 **Key features**:
@@ -21,10 +21,10 @@ complete with logging, validation, and redirects.
 * Form data can be logged and CSV-exported, sent via e-mail, or forwarded to any web address
 * Integration with `Django CMS <http://www.django-cms.org>`_: Add forms to any page
 * Use drag & drop to change the position of your form fields
-* Fully collapsible admin interface for better overview over your form 
+* Fully collapsible admin interface for better overview over your form
 * Implements many form fields included with Django (TextField, EmailField, DateField etc)
-* Validation rules as supplied by Django are fully configurable (maximum length, regular 
-  expression etc) 
+* Validation rules as supplied by Django are fully configurable (maximum length, regular
+  expression etc)
 * Customizable messages and labels
 * Supports POST and GET forms
 * Signals on form render, submission, success, error.
@@ -54,10 +54,10 @@ Basic setup
      public, this step is not necessary.
 
 
-Using Django Form Designer with Django CMS 
+Using Django Form Designer with Django CMS
 ==========================================
 
-- Add ``form_designer.contrib.cms_plugins.form_designer_form`` to your ``INSTALLED_APPS`` 
+- Add ``form_designer.contrib.cms_plugins.form_designer_form`` to your ``INSTALLED_APPS``
   setting::
 
         INSTALLED_APPS = (
@@ -65,7 +65,7 @@ Using Django Form Designer with Django CMS
             'form_designer.contrib.cms_plugins.form_designer_form',
         )
 
-You can now add forms to pages created with Django CMS. 
+You can now add forms to pages created with Django CMS.
 
 
 Optional requirements

--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -18,6 +18,7 @@ from form_designer.fields import ModelNameField, RegexpExpressionField, Template
 from form_designer.utils import get_random_hash, string_template_replace
 from picklefield.fields import PickledObjectField
 
+
 MAIL_TEMPLATE_CONTEXT_HELP_TEXT = _(
     'Your form fields are available as template context. '
     'Example: "{{ first_name }} {{ last_name }} <{{ from_email }}>" '
@@ -96,11 +97,15 @@ class FormDefinition(models.Model):
             field_dict[field.name] = field
         return field_dict
 
-    @models.permalink
     def get_absolute_url(self):
+        try:
+            from django.urls import reverse
+        except ImportError:
+            from django.core.urlresolvers import reverse
+
         if self.require_hash:
-            return ('form_designer.views.detail_by_hash', [str(self.public_hash)])
-        return ('form_designer.views.detail', [str(self.name)])
+            return reverse('form_designer.views.detail_by_hash', [str(self.public_hash)])
+        return reverse('form_designer.views.detail', [str(self.name)])
 
     def get_form_data(self, form):
         # TODO: refactor, move to utils or views

--- a/form_designer/uploads.py
+++ b/form_designer/uploads.py
@@ -30,14 +30,15 @@ def clean_files(form):
             else:
                 continue
         else:
-            total_upload_size += uploaded_file._size
+            file_size = uploaded_file.size
+            total_upload_size += file_size
             if not os.path.splitext(uploaded_file.name)[1].lstrip('.').lower() in  \
                     app_settings.ALLOWED_FILE_TYPES:
                 msg = _('This file type is not allowed.')
-            elif uploaded_file._size > app_settings.MAX_UPLOAD_SIZE:
+            elif file_size > app_settings.MAX_UPLOAD_SIZE:
                 msg = _('Please keep file size under %(max_size)s. Current size is %(size)s.') %  \
                     {'max_size': filesizeformat(app_settings.MAX_UPLOAD_SIZE),
-                     'size': filesizeformat(uploaded_file._size)}
+                     'size': filesizeformat(file_size)}
         if msg:
             form._errors[field.name] = form.error_class([msg])
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{27,34}-django{17}-djcms{32}
     py{27,34,35,36}-django{18,19}-djcms{32,33,34}
     py{27,34,35,36}-django{110,111}-djcms{34}
-    py{34,36}-django{20}
+    py{35,36}-django{20,21}
 
 skip_missing_interpreters = true
 
@@ -24,7 +24,8 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    django20: Django~=2.0
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     mysqlclient
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,12 @@ envlist =
 
 skip_missing_interpreters = true
 
-[tox:travis]
-2.7 = py27
-3.4 = py34
-3.5 = py35
-3.6 = py36
+[travis]
+python =
+  2.7: py27
+  3.4: py34
+  3.5: py35
+  3.6: py36
 
 [testenv]
 deps =
@@ -27,7 +28,6 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     mysqlclient
-    pytest
     pytest-cov
     pytest-django
     xlwt

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     pytest-django
     xlwt
 commands =
+    pip install pytest-django
     py.test -ra --cov form_designer --cov-report term --cov-report html form_designer {posargs}
 setenv =
     DEBUG = 1


### PR DESCRIPTION
<del>⚠️ This also drops official support for old, EOL versions of Django (i.e. <1.11).</del>