### PR TITLE
More Django 2.1+ compatibility

### DIFF
--- a/form_designer/__init__.py
+++ b/form_designer/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'form_designer.apps.FormDesignerConfig'

--- a/form_designer/admin.py
+++ b/form_designer/admin.py
@@ -126,11 +126,7 @@ class FormLogAdmin(admin.ModelAdmin):
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
-        try:
-            query_string = '?' + request.META['QUERY_STRING']
-        except (TypeError, KeyError):
-            query_string = ''
-
+        query_string = '?' + request.META.get('QUERY_STRING', '')
         exporter_links = []
         for cls in self.get_exporter_classes():
             url = reverse('admin:form_designer_export', args=(cls.export_format(),)) + query_string

--- a/form_designer/admin.py
+++ b/form_designer/admin.py
@@ -49,9 +49,9 @@ class FormDefinitionAdmin(admin.ModelAdmin):
 
 
 class FormLogAdmin(admin.ModelAdmin):
-    list_display = ('form_no_link', 'created', 'id', 'created_by', 'data_html')
+    list_display = ('form_definition', 'created', 'id', 'created_by', 'data_html')
     list_filter = ('form_definition',)
-    list_display_links = ()
+    list_display_links = None
     date_hierarchy = 'created'
 
     exporter_classes = {}
@@ -73,13 +73,6 @@ class FormLogAdmin(admin.ModelAdmin):
             actions[cls.export_format()] = (cls.export_view, cls.export_format(), desc)
 
         return actions
-
-    # Disabling all edit links: Hack as found at http://stackoverflow.com/questions/1618728/disable-link-to-edit-object-in-djangos-admin-display-list-only
-    def form_no_link(self, obj):
-        return '<a>%s</a>' % obj.form_definition
-    form_no_link.admin_order_field = 'form_definition'
-    form_no_link.allow_tags = True
-    form_no_link.short_description = _('Form')
 
     def get_urls(self):
         urls = [

--- a/form_designer/admin.py
+++ b/form_designer/admin.py
@@ -100,19 +100,22 @@ class FormLogAdmin(admin.ModelAdmin):
         """
         The 'change list' admin view for this model.
         """
-        list_display = self.get_list_display(request)
-        list_display_links = self.get_list_display_links(request, list_display)
-        list_filter = self.get_list_filter(request)
-        ChangeList = self.get_changelist(request)
+        if hasattr(self, 'get_changelist_instance'):  # Available on Django 2.0+
+            cl = self.get_changelist_instance(request)
+        else:
+            list_display = self.get_list_display(request)
+            list_display_links = self.get_list_display_links(request, list_display)
+            list_filter = self.get_list_filter(request)
+            ChangeList = self.get_changelist(request)
 
-        cl = ChangeList(request, self.model, list_display,
-                        list_display_links, list_filter, self.date_hierarchy,
-                        self.search_fields, self.list_select_related,
-                        self.list_per_page, self.list_max_show_all, self.list_editable,
-                        self)
+            cl = ChangeList(request, self.model, list_display,
+                            list_display_links, list_filter, self.date_hierarchy,
+                            self.search_fields, self.list_select_related,
+                            self.list_per_page, self.list_max_show_all, self.list_editable,
+                            self)
 
-        if hasattr(cl, "get_query_set"):  # Old Django versions
-            return cl.get_query_set(request)
+            if hasattr(cl, "get_query_set"):  # Old Django versions
+                return cl.get_query_set(request)
         return cl.get_queryset(request)
 
     def export_view(self, request, format):

--- a/form_designer/admin.py
+++ b/form_designer/admin.py
@@ -10,6 +10,11 @@ from form_designer import settings
 from form_designer.forms import FormDefinitionFieldInlineForm, FormDefinitionForm
 from form_designer.models import FormDefinition, FormDefinitionField, FormLog
 
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
+
 
 class FormDefinitionFieldInline(admin.StackedInline):
     form = FormDefinitionFieldInlineForm
@@ -117,7 +122,6 @@ class FormLogAdmin(admin.ModelAdmin):
         return self.exporter_classes[format](self.model).export(request, queryset)
 
     def changelist_view(self, request, extra_context=None):
-        from django.core.urlresolvers import reverse
         extra_context = extra_context or {}
         try:
             query_string = '?' + request.META['QUERY_STRING']

--- a/form_designer/models.py
+++ b/form_designer/models.py
@@ -18,12 +18,17 @@ from form_designer.fields import ModelNameField, RegexpExpressionField, Template
 from form_designer.utils import get_random_hash, string_template_replace
 from picklefield.fields import PickledObjectField
 
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 MAIL_TEMPLATE_CONTEXT_HELP_TEXT = _(
     'Your form fields are available as template context. '
     'Example: "{{ first_name }} {{ last_name }} <{{ from_email }}>" '
     'if you have fields named `first_name`, `last_name`, `from_email`.'
 )
+
 
 class FormValueDict(dict):
     def __init__(self, name, value, label):
@@ -98,11 +103,6 @@ class FormDefinition(models.Model):
         return field_dict
 
     def get_absolute_url(self):
-        try:
-            from django.urls import reverse
-        except ImportError:
-            from django.core.urlresolvers import reverse
-
         if self.require_hash:
             return reverse('form_designer.views.detail_by_hash', [str(self.public_hash)])
         return reverse('form_designer.views.detail', [str(self.name)])
@@ -147,6 +147,7 @@ class FormDefinition(models.Model):
 
     def count_fields(self):
         return self.formdefinitionfield_set.count()
+
     count_fields.short_description = _('Fields')
 
     def __str__(self):
@@ -210,7 +211,6 @@ class FormDefinition(models.Model):
 
 @python_2_unicode_compatible
 class FormDefinitionField(models.Model):
-
     form_definition = models.ForeignKey(FormDefinition, on_delete=models.CASCADE)
     field_class = models.CharField(_('field class'), max_length=100)
     position = models.IntegerField(_('position'), blank=True, null=True)

--- a/form_designer/tests/conftest.py
+++ b/form_designer/tests/conftest.py
@@ -1,10 +1,14 @@
 import pytest
+from django.utils.crypto import get_random_string
+
+from form_designer.models import FormLog
 
 
 @pytest.fixture()
 def greeting_form():
     from form_designer.models import FormDefinition, FormDefinitionField
     fd = FormDefinition.objects.create(
+        name=get_random_string(),
         mail_to='test@example.com',
         mail_subject='Someone sent you a greeting: {{ greeting }}',
         mail_reply_to='Greeting Bot <greetingbot@example.com>',
@@ -23,3 +27,13 @@ def greeting_form():
         required=False,
     )
     return fd
+
+
+@pytest.fixture()
+def greeting_form_with_log(admin_user, greeting_form):
+    log = FormLog.objects.create(
+        form_definition=greeting_form,
+        created_by=admin_user,
+    )
+    log.values.create(field_name='greeting', value=get_random_string())
+    return greeting_form

--- a/form_designer/tests/test_admin.py
+++ b/form_designer/tests/test_admin.py
@@ -6,8 +6,8 @@ from form_designer.models import FormDefinition
 
 
 @pytest.mark.django_db
-def test_admin_list_view_renders(admin_client):
-    assert admin_client.get("/admin/form_designer/formdefinition/").content
+def test_admin_list_view_renders(admin_client, greeting_form):
+    assert greeting_form.name in admin_client.get("/admin/form_designer/formdefinition/").content.decode()
 
 
 @pytest.mark.django_db
@@ -79,3 +79,21 @@ def test_admin_create_view_creates_form(admin_client, n_fields):
                 assert data[key] == value or value is None
             else:
                 assert data[key] == value
+
+
+@pytest.mark.django_db
+def test_admin_list_view_renders(admin_client, greeting_form_with_log):
+    log = greeting_form_with_log.logs.first()
+    greeting_value = log.data[0]['value']
+    assert greeting_value in admin_client.get("/admin/form_designer/formlog/").content.decode()
+
+
+@pytest.mark.django_db
+def test_admin_create_view_renders(admin_client, greeting_form_with_log):
+    assert admin_client.get("/admin/form_designer/formlog/add/").content
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('format', ('CSV', 'XLS'))
+def test_admin_export_view(admin_client, greeting_form_with_log, format):
+    assert admin_client.get("/admin/form_designer/formlog/export/%s/" % format).content

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,11 @@ deps =
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    mysqlclient
-    pytest-cov
     django17: pytest-django>=3.1,<3.2
     django{18,19,110,111,20}: pytest-django
+    mysqlclient
+    pytest-cov
+    pytz
     xlwt
 commands =
     pip install pytest-django


### PR DESCRIPTION
Turns out the form log admin was utterly broken, and had been untested.

As of this PR, it's no longer either.