### PR TITLE
Tox: Use pytest 3 and mysqlclient 1.3 for older stuff

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     djcms32: django-cms~=3.2.0
     djcms33: django-cms~=3.3.0
     djcms34: django-cms~=3.4.5
+
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
@@ -27,12 +28,20 @@ deps =
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+
     django17: pytest-django>=3.1,<3.2
-    django{18,19,110,111,20}: pytest-django
-    mysqlclient
+    django{18,19,110,111,20,21}: pytest-django
+
+    django17: pytest<4
+    django{18,19,110,111,20,21}: pytest
+
+    py34: mysqlclient<1.4
+    py{27,35,36}: mysqlclient
+
     pytest-cov
     pytz
     xlwt
+
 commands =
     pip install pytest-django
     py.test -ra --cov form_designer --cov-report term --cov-report html form_designer {posargs}


### PR DESCRIPTION
It seems that pytest 4 does not work with Django 1.7, so use older
pytest for running the Django 1.7 tests.

Also there seems to be some problems with mysqlclient 1.4 on Python 3.4,
so use mysqlclient 1.3 on Python 3.4.