### PR TITLE
Fix python3 TypeError on checking google recaptcha

### DIFF
--- a/form_designer/views.py
+++ b/form_designer/views.py
@@ -35,7 +35,7 @@ def check_recaptcha(request, context, push_messages):
         'secret': app_settings.GOOGLE_RECAPTCHA_SECRET_KEY,
         'response': recaptcha_response
     }
-    data = urlencode(values)
+    data = urlencode(values).encode('utf-8')
     req = Request(url, data)
     response = urlopen(req)
     result = json.load(response)


### PR DESCRIPTION
When used with python3, output from urlencode has to be encoded to bytes
before it is sent to urlopen as data.

https://docs.python.org/3.4/library/urllib.request.html#urllib-examples