### PR TITLE
Add on_delete args to CMS plugin migration for Django 2 support

### DIFF
--- a/form_designer/contrib/cms_plugins/form_designer_form/migrations/0001_initial.py
+++ b/form_designer/contrib/cms_plugins/form_designer_form/migrations/0001_initial.py
@@ -30,11 +30,13 @@ class Migration(migrations.Migration):
                      primary_key=True,
                      to='cms.CMSPlugin',
                      parent_link=True,
+                     on_delete=models.CASCADE,
                      **field_kwargs)),
                 ('form_definition',
                  models.ForeignKey(
                      verbose_name='form',
-                     to='form_designer.FormDefinition')),
+                     to='form_designer.FormDefinition',
+                     on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,


### PR DESCRIPTION
Add the explicit `on_delete` arguments to `ForeignKey` and `OneToOneField` in the Django CMS plugin migration, as required by Django 2.x.